### PR TITLE
update getMyPackageLicense to parse pyproject.toml configured according to setuptools standards

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -143,6 +143,9 @@ def getClassifiersLicense() -> dict[str, Any]:
 			return tool["poetry"]
 		if "flit" in tool:
 			return tool["flit"]["metadata"]
+		if pyproject.get("project") is not None:
+			return pyproject["project"]
+
 	return {"classifiers": [], "license": ""}
 
 
@@ -158,7 +161,10 @@ def getMyPackageLicense() -> str:
 	if licenseClassifier != UNKNOWN:
 		return licenseClassifier
 	if "license" in metaData:
-		return str(metaData["license"])
+		if isinstance(metaData["license"], dict) and metaData["license"].get("text") is not None:
+			return str(metaData["license"].get("text"))
+		else:
+			return str(metaData["license"])
 	return input("Enter the project license")
 
 


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
I updated the `packageinfo.getClassifiersLicense` and `packageinfo.getMyPackageLicense` functions.

### Which issue (if any) does this pull request address?
Fixes #23 

### Is there anything you'd like reviewers to focus on?
This PR introduces a parsing solution to retrieve the package licence in chase the pyproject.toml file is configured according to [setuptools' standards](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).

You can use the configurations prototype defined in the link above (reported here for convenience):
```
build-system]
requires = ["setuptools", "setuptools-scm"]
build-backend = "setuptools.build_meta"

[project]
name = "my_package"
description = "My package description"
readme = "README.rst"
requires-python = ">=3.7"
keywords = ["one", "two"]
license = {text = "BSD 3-Clause License"}
classifiers = [
    "Framework :: Django",
    "Programming Language :: Python :: 3",
]
dependencies = [
    "requests",
    'importlib-metadata; python_version<"3.8"',
]
dynamic = ["version"]

[project.optional-dependencies]
pdf = ["ReportLab>=1.2", "RXP"]
rest = ["docutils>=0.3", "pack ==1.1, ==1.3"]

[project.scripts]
my-script = "my_package.module:function"

# ... other project metadata fields as specified in:
#     https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
```
