### PR TITLE
[ISSUE-26] Fix python 3.8 compatibilty

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import configparser
-from importlib import metadata, resources
+import sys
+from importlib import metadata
+if sys.version_info < (3, 9, 0):
+    import importlib_resources as ilr
+else:
+    import importlib.resources as ilr
 from pathlib import Path
 from typing import Any, cast
 
@@ -33,7 +38,7 @@ def getPackageInfoLocal(requirement: str) -> PackageInfo:
 		version = pkgMetadata.get("Version", UNKNOWN)
 		size = 0
 		try:
-			packagePath = resources.files(requirement)
+			packagePath = ilr.files(requirement)
 			size = getModuleSize(cast(Path, packagePath), name)
 		except TypeError:
 			pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requests = "<3,>=2.28.1"
 fhconfparser = "<2024,>=2022"
 tomli = "<3,>=2.0.1"
 rich = "<13,>=12.6.0"
+importlib-resources = { version = ">=3.0.0", python = "<3.9" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fhconfparser<2024,>=2022
+importlib-resources>=3.0.0;python_version<'3.9'
 requests<3,>=2.28.1
 requirements-parser<2,>=0.5.0
 rich<13,>=12.6.0


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [X ] Other, please explain: Fix python 3.8 compatibility

### What changes did you make? (Give an overview)
I added a check on python version in `licensecheck.packageinfo` to use `importlib_resources` instead of `importlib.resources` if python_version < 3.9.

### Which issue (if any) does this pull request address?
Fixes #26 

### Is there anything you'd like reviewers to focus on?

I tested my changes using an image built from the following Dockerfile (that I didn't commit since I am not sure if it does fit with the project structure)

```
# syntax=docker/dockerfile:1

ARG  PY_VERSION=3.8
FROM python:${PY_VERSION}-buster as builder

WORKDIR /app

RUN apt-get update && apt-get upgrade -y

COPY LICENSE.md README.md pyproject.toml ./
COPY licensecheck/ licensecheck/
COPY requirements.txt requirements.txt

RUN pip install poetry
RUN poetry config virtualenvs.create false && poetry install
CMD licensecheck -u requirements:requirements.txt --zero
```
