### PR TITLE
fix: properly parse packages without pypi classifiers

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -91,6 +91,8 @@ def licenseFromClassifierlist(classifiers: list[str]) -> str:
 	Returns:
 		str: the license name
 	"""
+	if not classifiers:
+		return UNKNOWN
 	licenses = []
 	for val in classifiers:
 		if val.startswith("License"):

--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -175,9 +175,15 @@ def getModuleSize(path: Path, name: str) -> int:
 	Returns:
 		int: size in bytes
 	"""
-	size = sum(
-		f.stat().st_size for f in path.glob("**/*") if f.is_file() and "__pycache__" not in str(f)
-	)
+	size = 0
+	try:
+		size = sum(
+			f.stat().st_size
+			for f in path.glob("**/*")
+			if f.is_file() and "__pycache__" not in str(f)
+		)
+	except AttributeError:
+		pass
 	if size > 0:
 		return size
 	request = requests.get(f"https://pypi.org/pypi/{name}/json", timeout=60)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

### What is the purpose of this pull request?

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make?
Added a fix for parsing packages from PyPI without any classifiers.
Added a try-catch clause for size calculation.

### Which issue (if any) does this pull request address?
#28 
#30 

### Is there anything you'd like reviewers to focus on?
Packages that should result in errors:
Issue 28 - `jsbeautifier`
Issue 30 - `mkdocstrings`