### PR TITLE
Added ability to resolve dependencies from PEP631 based pyproject.tom…

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,26 @@ Add `-u poetry:dev` to command-line to include dev packages (excluded by default
 └────────────┴─────────────────────┴───────────────────────────────────────────────┘
 ```
 
+### PEP 631 (with or without optional dependencies)
+
+PEP 631 mode enables support for reading dependency information from `pyproject.yaml` in the format specified by PEP 631.
+This format is used by build systems such as hatch.
+
+You can enable this mode by using `-u PEP631`, and include the optional dependencies of extras by using `-u PEP631:tests;dev;docs`, 
+but it's recommended to use this instead:
+
+```toml
+[tool.licensecheck]
+using = "PEP631"
+
+# OR
+
+[tool.licensecheck]
+using = "PEP631:tests;dev;docs"
+```
+
+By default no optional dependencies are included.
+
 ## Help
 
 ```txt
@@ -266,7 +286,7 @@ options:
                         Output format. one of: json, markdown, csv, ansi, simple. default=simple
   --file FILE, -o FILE  Filename to write to (omit for stdout)
   --using USING, -u USING
-                        Environment to use e.g. requirements.txt. one of: requirements, poetry. default=poetry
+                        Environment to use e.g. requirements.txt. one of: requirements, poetry, PEP631. default=poetry
   --ignore-packages IGNORE_PACKAGES [IGNORE_PACKAGES ...]
                         a list of packages to ignore (compat=True)
   --fail-packages FAIL_PACKAGES [FAIL_PACKAGES ...]

--- a/licensecheck/__init__.py
+++ b/licensecheck/__init__.py
@@ -101,7 +101,7 @@ def cli() -> None:
 	# Format the results
 	if simpleConf.get("format", "simple") in formatter.formatMap:
 		print(
-			formatter.formatMap[simpleConf.get("format", "simple")](list(depsWithLicenses)),
+			formatter.formatMap[simpleConf.get("format", "simple")](sorted(depsWithLicenses)),
 			file=filename,
 		)
 	else:

--- a/licensecheck/license_matrix.py
+++ b/licensecheck/license_matrix.py
@@ -208,6 +208,7 @@ def depCompatWMyLice(
 		L.MPL: LGPL + GPL + [L.EU],
 		L.EU: PERMISSIVE_GPL_INCOMPATIBLE + LGPL + GPL + [L.MPL],
 		L.PROPRIETARY: PERMISSIVE_INCOMPATIBLE,
+		L.NO_LICENSE: PERMISSIVE_INCOMPATIBLE,
 	}
 	# Protect against None
 	failLicenses = failLicenses or []

--- a/licensecheck/types.py
+++ b/licensecheck/types.py
@@ -9,7 +9,7 @@ UNKNOWN = "UNKNOWN"
 JOINS = ";; "
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(unsafe_hash=True, order=True)
 class PackageInfo:
 	"""PackageInfo type."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "licensecheck"
-version = "2023.0.1"
+version = "2023.1.0"
 license = "mit"
 description = "Output the licenses used by dependencies and check if these are compatible with the project license"
 authors = ["FredHappyface"]

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+# Added to example.
+license = "gpl-3.0-or-later"
+
+# Example copied from https://peps.python.org/pep-0631/#example
+dependencies = [
+    'cached-property >= 1.2.0, < 2',
+    'distro >= 1.5.0, < 2',
+    'docker[ssh] >= 4.2.2, < 5',
+    'dockerpty >= 0.4.1, < 1',
+    'docopt >= 0.6.1, < 1',
+    'jsonschema >= 2.5.1, < 4',
+    'PyYAML >= 3.10, < 6',
+    'python-dotenv >= 0.13.0, < 1',
+    'requests >= 2.20.0, < 3',
+    'texttable >= 0.9.0, < 2',
+    'websocket-client >= 0.32.0, < 1',
+
+    # Conditional
+    'backports.shutil_get_terminal_size == 1.0.0; python_version < "3.3"',
+    'backports.ssl_match_hostname >= 3.5, < 4; python_version < "3.5"',
+    'colorama >= 0.4, < 1; sys_platform == "win32"',
+    'enum34 >= 1.0.4, < 2; python_version < "3.4"',
+    'ipaddress >= 1.0.16, < 2; python_version < "3.3"',
+    'subprocess32 >= 3.5.4, < 4; python_version < "3.2"',
+]
+
+[project.optional-dependencies]
+socks = [ 'PySocks >= 1.5.6, != 1.5.7, < 2' ]
+tests = [
+    'ddt >= 1.2.2, < 2',
+    'pytest < 6',
+    'mock >= 1.0.1, < 4; python_version < "3.4"',
+]
+
+# Added to example.
+[tool.licensecheck]
+using = "PEP631:socks"


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)

Changed as little as possible to enable the extraction of `project.dependencies` and `project.optional-dependencies` from `pyproject.toml` in line with PEP 631, as used by Hatch for example.

### Which issue (if any) does this pull request address?

#32

### Is there anything you'd like reviewers to focus on?

You can test the implementation by running the program inside of the `tests/data` folder, as the `pyproject.toml` file there will take priority and be used as the config file. It specifies that the PEP631 format should be used, so it becomes sort of "self referential".
