### PR TITLE
[ISSUE-38] Change size computation in getPackageInfoLocal

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -37,12 +37,7 @@ def getPackageInfoLocal(requirement: str) -> PackageInfo:
 		author = pkgMetadata.get("Author", UNKNOWN)
 		name = pkgMetadata.get("Name", UNKNOWN)
 		version = pkgMetadata.get("Version", UNKNOWN)
-		size = 0
-		try:
-			packagePath = ilr.files(requirement)
-			size = getModuleSize(cast(Path, packagePath), name)
-		except TypeError:
-			pass
+		size = sum([pp.size for pp in metadata.Distribution.from_name(requirement).files if pp.size is not None])
 		# append to pkgInfo
 		return PackageInfo(
 			name=name,
@@ -53,7 +48,7 @@ def getPackageInfoLocal(requirement: str) -> PackageInfo:
 			license=lice,
 		)
 
-	except (metadata.PackageNotFoundError, ModuleNotFoundError) as error:
+	except metadata.PackageNotFoundError as error:
 		raise ModuleNotFoundError from error
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
Changes the way package size is computed in getPackageInfoLocal to avoid throwing a ModuleNotFound error (and thus returning an UNKNWON license) when the locally installed package is a namespace package (that cannot be loaded easily with `importlib.import_module`)

### Which issue (if any) does this pull request address?
Fixes #38 

### Is there anything you'd like reviewers to focus on?
The size computed by metadata.Distribution is not the same as the on retrieved by PyPI (for published packages, ofc). These measurements can differ significantly but, since this information is actually of no use for license comparison, I wouldn't care very much about understanding the motivations of this difference and try to solve it.