### PR TITLE
Fix #53 (ignore-package not working)

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -162,7 +162,7 @@ def getDepsWithLicenses(
 	for package in packages:
 		# Deal with --ignore-packages and --fail-packages
 		package.licenseCompat = False
-		packageName = package.name
+		packageName = package.name.upper()
 		if packageName in ignorePackages:
 			package.licenseCompat = True
 		elif packageName in failPackages:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
Package names to be ignored or auto-failed are stored in upper-case in the config object. Hence, the package name to check also needs to be converted to upper-case.

### Which issue (if any) does this pull request address?
This fixes #53, although there might still be the problem of the need for using underscores (`ignore_packages` instead of `ignore-packages`) in toml files as stated in the first answer of that issue.

### Is there anything you'd like reviewers to focus on?
