### PR TITLE
fix: handle missing urls for a pypi package

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -62,12 +62,18 @@ def getPackageInfoPypi(requirement: ucstr) -> PackageInfo:
 	try:
 		info = response["info"]
 		licenseClassifier = licenseFromClassifierlist(info["classifiers"])
+
+		size = -1
+		urls = response.get("urls", [])
+		if urls:
+			size = int(urls[-1]["size"])
+
 		return PackageInfo(
 			name=info["name"],
 			version=info["version"],
 			homePage=info["home_page"],
 			author=info["author"],
-			size=int(response["urls"][-1]["size"]),
+			size=size,
 			license=ucstr(
 				licenseClassifier if licenseClassifier != UNKNOWN else info.get("license", UNKNOWN)
 			),


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make?

This fix just verify if pypi response contains a not empty list of `urls` to determine package size. If the list is empty it fallback on `size = -1`

### Which issue (if any) does this pull request address?

https://github.com/FredHappyface/.github/issues/3

### Is there anything you'd like reviewers to focus on?

Nop :)
