### PR TITLE
Fix optional extras from dependencies being included by default (#1)

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -155,7 +155,7 @@ def _doGetReqs(
 	for requirement in reqs:
 		try:
 			pkgMetadata = metadata.metadata(requirement)
-			for dependency in pkgMetadata.get_all("Require-Dist") or []:
+			for dependency in pkgMetadata.get_all("Requires-Dist") or []:
 				update_dependencies(dependency)
 		except metadata.PackageNotFoundError:
 			request = session.get(


### PR DESCRIPTION
### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

Hope to fix the following:
- Additional extras from downstream dependencies say optional dependencies grouped under `dev`, `test`, etc were not being filtered out resulting in `pytest` and other packages always being included by default. 
- More than one extras specified for downstream dependencies were being ignored e.g. `httpx[brotli,cli,socks]`.

### Related Issue

Fixes #52 

### Reviewer Notes

#### Case 1 downstream extras not being filtered

pyproject.toml

```toml
dependencies = [
    "loguru~=0.6.0",
]
```

Currently lists the following:

![Screenshot 2023-09-15 at 4 47 45 pm](https://github.com/FHPythonUtils/LicenseCheck/assets/22039168/ce802ba9-28fb-44d2-8c5f-cb8503608cfa)

And, with the fix:

![Screenshot 2023-09-15 at 5 51 26 pm](https://github.com/FHPythonUtils/LicenseCheck/assets/22039168/929422ec-8b5e-4a5c-be00-05d449f174c9)


#### Case 2 Extras more than one are ignored

Though `httpx[brotli]` is fine `httpx[brotli,cli,socks]` doesn't collate all the extras.

pyproject.toml

```toml
dependencies = [
    "httpx[brotli,cli,socks]~=0.23.3", 
]
```

Currently lists the following:

![Screenshot 2023-09-15 at 4 48 28 pm](https://github.com/FHPythonUtils/LicenseCheck/assets/22039168/6e9a29ca-c3bb-4fba-ba6a-b73e56203114)

And, with the fix:

![Screenshot 2023-09-15 at 5 51 56 pm](https://github.com/FHPythonUtils/LicenseCheck/assets/22039168/fa88a537-0a48-4cfa-a99e-4571019a4803)


