### PR TITLE
Handle both single and double quotes in extras

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -78,7 +78,7 @@ def _doGetReqs(
 		return canonicalName if extra else name
 
 	def resolveExtraReq(extraReq: str) -> ucstr | None:
-		match = re.search(r"extra\s*==\s*'(.*?)'", extraReq)
+		match = re.search(r"extra\s*==\s*[\"'](.*?)[\"']", extraReq)
 		if match is None:
 			return None
 		return ucstr(match.group(1))


### PR DESCRIPTION
### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

The current logic only accounts for single quotes instead of handling both `'` (single quotes) and `"` (double quotes) when parsing the extras specification. For example, when parsing the extras for `typer`, all optional extras are also being included by default as a dependency.

e.g. 

```
>>> from licensecheck.get_deps import getReqs
>>> getReqs("requirements:test-reqs.txt", [])
{'MKDOCS', 'TYPING-EXTENSIONS', 'PYTEST-COV', 'PYTEST-SUGAR', 'COLORAMA', 'MKDOCS-MATERIAL', 'FLAKE8', 'PILLOW', 'MDX-INCLUDE', 'SHELLINGHAM', 'COVERAGE', 'CLICK', 'AUTOFLAKE', 'TYPER', 'MYPY', 'ISORT', 'BLACK', 'RICH', 'PYTEST', 'PRE-COMMIT', 'PYTEST-XDIST', 'CAIROSVG'}
>>> with open('test-reqs.txt') as f: f.read()
... 
'typer'
```

And, with the proposed fix:

```
>>> from licensecheck.get_deps import getReqs
>>> getReqs("requirements:test-reqs.txt", [])
{'TYPING-EXTENSIONS', 'TYPER', 'CLICK'}
>>> 
>>> with open('test-reqs.txt') as f: f.read()
... 
'typer'
```

### Related Issue

Fixes #63

