### PR TITLE
Added option --only-licenses to allow whitelisting of licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,32 @@ See below for the output if you run `licensecheck` in this directory
 └────────────┴─────────────────────┴──────────────────────────────────────┘
 ```
 
+### Only allow a predefined set of licenses
+
+```txt
+
+>> licensecheck --only-licenses mit
+
+                             list of packages
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Compatible ┃ Package             ┃ License(s)                           ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ✖          │ idna                │ BSD License                          │
+│ ✖          │ certifi             │ Mozilla Public License 2.0 (MPL 2.0) │
+│ ✖          │ Pygments            │ BSD License                          │
+│ ✖          │ commonmark          │ BSD License                          │
+│ ✖          │ requirements-parser │ Apache Software License              │
+│ ✔          │ fhconfparser        │ MIT License                          │
+│ ✔          │ tomli               │ MIT License                          │
+│ ✖          │ types-setuptools    │ Apache Software License              │
+│ ✔          │ attrs               │ MIT License                          │
+│ ✔          │ charset-normalizer  │ MIT License                          │
+│ ✔          │ rich                │ MIT License                          │
+│ ✔          │ urllib3             │ MIT License                          │
+│ ✖          │ requests            │ Apache Software License              │
+└────────────┴─────────────────────┴──────────────────────────────────────┘
+```
+
 ### Custom requirements.txt in json format
 
 Add optional path to requirements.txt as outlined in https://github.com/FHPythonUtils/LicenseCheck/issues/9#issuecomment-898878228. Eg. `licensecheck --using requirements:c:/path/to/reqs.txt;path/to/other/reqs.txt`

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ usage: __main__.py [-h] [--format FORMAT] [--file FILE] [--using USING]
                    [--ignore-packages IGNORE_PACKAGES [IGNORE_PACKAGES ...]]
                    [--fail-packages FAIL_PACKAGES [FAIL_PACKAGES ...]]
                    [--ignore-licenses IGNORE_LICENSES [IGNORE_LICENSES ...]]
-                   [--fail-licenses FAIL_LICENSES [FAIL_LICENSES ...]] [--zero]
+                   [--fail-licenses FAIL_LICENSES [FAIL_LICENSES ...]]
+                   [--only_licenses ONLY_LICENSES [ONLY_LICENSES ...]] [--zero]
 
 Output the licenses used by dependencies and check if these are compatible with the project license.
 
@@ -330,6 +331,8 @@ options:
                         a list of licenses to ignore (skipped, compat may still be False)
   --fail-licenses FAIL_LICENSES [FAIL_LICENSES ...]
                         a list of licenses to fail (compat=False)
+  --only-licenses ONLY_LICENSES [ONLY_LICENSES ...]
+                        a list of allowed licenses (any other license will fail)
   --skip-dependencies SKIP_DEPENDENCIES [SKIP_DEPENDENCIES ...]
 						a list of dependencies to skip (compat=False)
   --zero, -0            Return non zero exit code if an incompatible license is found

--- a/licensecheck/__init__.py
+++ b/licensecheck/__init__.py
@@ -61,6 +61,11 @@ def cli() -> None:
 		nargs="+",
 	)
 	parser.add_argument(
+		"--only-licenses",
+		help="a list of allowed licenses (any other license will fail)",
+		nargs="+",
+	)
+	parser.add_argument(
 		"--skip-dependencies",
 		help="a list of packages to skip (compat=True)",
 		nargs="+",
@@ -104,6 +109,7 @@ def cli() -> None:
 		list(map(types.ucstr, simpleConf.get("fail_packages", []))),
 		list(map(types.ucstr, simpleConf.get("ignore_licenses", []))),
 		list(map(types.ucstr, simpleConf.get("fail_licenses", []))),
+		list(map(types.ucstr, simpleConf.get("only_licenses", []))),
 		list(map(types.ucstr, simpleConf.get("skip_dependencies", []))),
 	)
 

--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -176,6 +176,7 @@ def getDepsWithLicenses(
 	failPackages: list[ucstr],
 	ignoreLicenses: list[ucstr],
 	failLicenses: list[ucstr],
+	onlyLicenses: list[ucstr],
 	skipDependencies: list[ucstr],
 ) -> tuple[License, set[PackageInfo]]:
 	"""Get a set of dependencies with licenses and determine license compatibility.
@@ -188,6 +189,7 @@ def getDepsWithLicenses(
 		ignoreLicenses (list[ucstr]): a list of licenses to ignore (skipped, compat may still be
 		False)
 		failLicenses (list[ucstr]): a list of licenses to fail (compat=False)
+		onlyLicenses (list[ucstr]): a list of allowed licenses (any other license will fail)
 		skipDependencies (list[ucstr]): a list of dependencies to skip (compat=False)
 
 	Returns:
@@ -206,6 +208,7 @@ def getDepsWithLicenses(
 		ucstr(JOINS.join(ignoreLicenses)), ignoreLicenses
 	)
 	failLicensesType = license_matrix.licenseType(ucstr(JOINS.join(failLicenses)), ignoreLicenses)
+	onlyLicensesType = license_matrix.licenseType(ucstr(JOINS.join(onlyLicenses)), ignoreLicenses)
 
 	# Check it is compatible with packages and add a note
 	packages = packageinfo.getPackages(reqs)
@@ -224,5 +227,6 @@ def getDepsWithLicenses(
 				license_matrix.licenseType(package.license, ignoreLicenses),
 				ignoreLicensesType,
 				failLicensesType,
+				onlyLicensesType,
 			)
 	return myLice, packages

--- a/licensecheck/license_matrix.py
+++ b/licensecheck/license_matrix.py
@@ -137,6 +137,7 @@ def depCompatWMyLice(
 	depLice: list[L],
 	ignoreLicenses: list[L] | None = None,
 	failLicenses: list[L] | None = None,
+	onlyLicenses: list[L] | None = None,
 ) -> bool:
 	"""Identify if the end user license is compatible with the dependency license(s).
 
@@ -146,6 +147,7 @@ def depCompatWMyLice(
 		depLice (list[L]): dependency license
 		ignoreLicenses (list[L], optional): list of licenses to ignore. Defaults to None.
 		failLicenses (list[L], optional): list of licenses to fail on. Defaults to None.
+		onlyLicenses (list[L], optional): list of allowed licenses. Defaults to None.
 
 	Returns:
 	-------
@@ -156,6 +158,7 @@ def depCompatWMyLice(
 	# Protect against None
 	failLicenses = failLicenses or []
 	ignoreLicenses = ignoreLicenses or []
+	onlyLicenses = onlyLicenses or []
 
 	return any(
 		liceCompat(
@@ -163,6 +166,7 @@ def depCompatWMyLice(
 			lice,
 			ignoreLicenses,
 			failLicenses,
+			onlyLicenses,
 		)
 		for lice in depLice
 	)
@@ -173,6 +177,7 @@ def liceCompat(
 	lice: L,
 	ignoreLicenses: list[L],
 	failLicenses: list[L],
+	onlyLicenses: list[L],
 ) -> bool:
 	"""Identify if the end user license is compatible with the dependency license.
 
@@ -180,12 +185,15 @@ def liceCompat(
 	:param L lice: dependency license
 	:param list[L] ignoreLicenses: list of licenses to ignore. Defaults to None.
 	:param list[L] failLicenses: list of licenses to fail on. Defaults to None.
+	:param list[L] onlyLicenses: list of allowed licenses. Defaults to None.
 	:return bool: True if compatible, otherwise False
 	"""
 	if lice in failLicenses:
 		return False
 	if lice in ignoreLicenses:
 		return True
+	if onlyLicenses and (lice not in onlyLicenses):
+		return False
 	licenses = list(L)
 	row, col = licenses.index(myLicense) + 1, licenses.index(lice) + 1
 

--- a/tests/test_license_matrix.py
+++ b/tests/test_license_matrix.py
@@ -50,6 +50,13 @@ def test_dualLicenseCompat() -> None:
 	assert license_matrix.depCompatWMyLice(types.L.MIT, [types.L.GPL_2, types.L.MIT])
 
 
+def test_whitelistedLicenseCompat() -> None:
+	assert license_matrix.depCompatWMyLice(types.L.MIT, [types.L.MIT], onlyLicenses=[types.L.MIT])
+	assert license_matrix.depCompatWMyLice(types.L.MPL, [types.L.MIT], onlyLicenses=[types.L.MIT])
+	assert not license_matrix.depCompatWMyLice(types.L.MIT, [types.L.MIT], onlyLicenses=[types.L.MPL])
+	assert not license_matrix.depCompatWMyLice(types.L.MPL, [types.L.MIT], onlyLicenses=[types.L.MPL])
+
+
 def test_warningsForIgnoredLicense(caplog: LogCaptureFixture) -> None:
 	zope = types.ucstr("ZOPE PUBLIC LICENSE")
 	license_matrix.licenseLookup(zope, [])


### PR DESCRIPTION
### Purpose of This Pull Request

- [X] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other (please explain):

### Overview of Changes

I added a new option `--only-licenses` to allow whitelisting a set of licenses in a license check and updated the documentation accordingly

### Reviewer Focus

I made sure to match the code style and hope I didn't miss anything required for this change.

### Additional Notes

The idea behind this feature is that we would like to have our own whitelist of licenses we allow in our projects, instead of blacklisting all the licenses we don't allow in our projects.
