### PR TITLE
Draft: Support for unix pattern in packages

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 import tomli
@@ -120,17 +121,20 @@ def getDepsWithLicenses(
 		# Deal with --ignore-packages and --fail-packages
 		package.licenseCompat = False
 		packageName = package.name.upper()
-		if packageName in ignorePackages:
-			package.licenseCompat = True
-		elif packageName in failPackages:
-			pass  # package.licenseCompat = False
-		# Else get compat with myLice
+		for ignoredPattern in ignorePackages:
+			if fnmatchcase(packageName, ignoredPattern):
+				package.licenseCompat = True
+				break
 		else:
-			package.licenseCompat = license_matrix.depCompatWMyLice(
-				myLice,
-				license_matrix.licenseType(package.license, ignoreLicenses),
-				ignoreLicensesType,
-				failLicensesType,
-				onlyLicensesType,
-			)
+			if packageName in failPackages:
+				pass  # package.licenseCompat = False
+			# Else get compat with myLice
+			else:
+				package.licenseCompat = license_matrix.depCompatWMyLice(
+					myLice,
+					license_matrix.licenseType(package.license, ignoreLicenses),
+					ignoreLicensesType,
+					failLicensesType,
+					onlyLicensesType,
+				)
 	return packages


### PR DESCRIPTION
### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other (please explain):

### Overview of Changes

This MR adds Unix pattern support for ignored packages.

I have a very concrete case where I use Nvidia deep learning packages in a project, that come with a proprietary license that I know is compatible with my project, so each of the packages is marked as ignored in my pyproject file.

Since all Nvidia packages in my project have the same pattern (`nvidia-cublas-cu11`, `nvidia-cuda-cupti-cu11`, etc.), I wanted to compact the ignore-package section a bit. This MR enables to declare `nvidia-*-cu11` as ignored, using Unix style patterns and `fnmatchcase` function.


### Reviewer Focus

This MR is a draft, but I tested that the feature was working in my project.
I wanted to know if this was a good idea or not before maybe adding this feature to other sections, like maybe fail-packages, and adding tests and documentation.

### Additional Notes

I'm using Unix patterns instead of regexes for the sake of simplicity, but I am open to use regexes instead if needed.
