### PR TITLE
Corrected the logic to consider extras when using requirements

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -46,7 +46,7 @@ def getReqs(using: str, skipDependencies: list[ucstr]) -> set[ucstr]:
 
 	# Requirements
 	if using == "requirements":
-		requirementsPaths = ["requirements.txt"] if len(extras) > 0 else extras
+		requirementsPaths = ["requirements.txt"] if len(extras) == 0 else extras
 		extras = []
 
 	try:


### PR DESCRIPTION
### Purpose of This Pull Request

- [x] Bug fix

### Overview of Changes

Bug: When using requirements, irrespective of the arguments given, only requirements.txt is considered.
Fix: if no arguments are passed, only then consider requirements.txt. If arguments are passed then consider only them.
