### PR TITLE
Update packageinfo.py

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -162,7 +162,7 @@ def getMyPackageMetadata() -> dict[str, Any]:
 
 	if Path("pyproject.toml").exists():
 		pyproject = tomli.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-		tool = pyproject["tool"]
+		tool = pyproject.get("tool",{})
 		if "poetry" in tool:
 			return tool["poetry"]
 		if "flit" in tool:


### PR DESCRIPTION
### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes
tool might no be present with certain managers (e.g. uv). acessing tool with a empty dict fallback allows this to work

by changing 
```python
tool = pyproject["tool"]
```
to:
```python
tool = pyproject.get("tool", {})
```

simple pyproject.toml files according to PEP621 will still work since this line can be reached
```python
if pyproject.get("project") is not None:
    return pyproject["project"]
```
