### PR TITLE
Allow for alias of classifier in setup.cfg

### DIFF
--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -156,7 +156,10 @@ def getMyPackageMetadata() -> dict[str, Any]:
 		config = configparser.ConfigParser()
 		config.read("setup.cfg")
 		if "metadata" in config.sections() and "license" in config["metadata"]:
-			classifiers = config.get("metadata", "classifiers").strip().splitlines()
+			if "classifier" in config["metadata"]:
+				classifiers = config.get("metadata", "classifier").strip().splitlines()
+			else:
+				classifiers = config.get("metadata", "classifiers").strip().splitlines()
 			licenseStr = ucstr(config.get("metadata", "license"))
 			return {"classifiers": classifiers, "license": licenseStr}
 


### PR DESCRIPTION
### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

This change allows a setup.cfg file to define classifiers using the attribute of "classifier" in addition to "classifiers". The attribute "classifier" is an alias of "classifiers" according to the setuptools documentation.

### Related Issue

Fixes #105

### Reviewer Focus

n/a

### Additional Notes

n/a
