### PR TITLE
fix: color update on enforced envs

### DIFF
--- a/licensecheck/resolvers/uv.py
+++ b/licensecheck/resolvers/uv.py
@@ -33,7 +33,7 @@ def get_reqs(
 	groups_cmd = [f"--group {group}" for group in groups]
 	extras_cmd = [f"--extra {extra}" for extra in extras]
 	command = (
-		f"uv pip compile --index {index_url}"
+		f"uv pip compile --color never --index {index_url}"
 		f" {' '.join(requirementsPaths)} {' '.join(extras_cmd)} {' '.join(groups_cmd)}"
 	)
 


### PR DESCRIPTION
Disable color output at all (when using CLICOLOR_FORCE) to make output of uv pip parseable.

Otherwise the output contains color code and cannot be parsed by the parser.

<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

This patch onle applies ```--color never``` to the uv call to avoid color escape codes when enforced with CLICOLOR_FORCE

### Reviewer Focus

Only applies when using uv in the environment.

### Additional Notes

Test with:
```bash
CLICOLORFORCE=1 licensecheck
CLICOLORFORCE=0 licensecheck
```
