### PR TITLE
Add missing local metadata and allow local only metadata

### DIFF
--- a/licensecheck/cli.py
+++ b/licensecheck/cli.py
@@ -97,7 +97,11 @@ def cli() -> None:  # pragma: no cover
 	)
 	parser.add_argument(
 		"--pypi-api",
-		help="Specify a custom pypi api endpoint, for example if using a custom pypi server",
+		help=(
+			"Specify a custom PyPI server URL "
+			"(it must implement PyPI /json details API, in addition to the /simple search API); "
+			"if set to empty string, metadata will only be obtained from local packages"
+		),
 		default="https://pypi.org",
 	)
 	parser.add_argument(

--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 from email.message import Message
 from importlib import metadata
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import license_expression
 import requests
@@ -24,19 +24,28 @@ from licensecheck.types import JOINS, UNKNOWN, PackageInfo, ucstr
 
 RAW_JOINS = " AND "
 
+VT = TypeVar("VT")
+
+
+def get_first_not_null(gen: Iterable[VT | None]) -> VT | None:
+	try:
+		return next(iter(v for v in gen if v is not None))
+	except StopIteration:
+		return None
+
 
 class PackageInfoManager:
 	"""Manages retrieval of local and remote package information."""
 
-	def __init__(self, base_pypi_url: str = "https://pypi.org") -> None:
-		"""Manage retrieval of local and remote package information.
+	def __init__(self, base_pypi_url: str | None = "https://pypi.org") -> None:
+		"""Manage retrieval of local, and remote package information (unless no base_pypi_url).
 
 		:param str pypi_api: url of pypi server. Typically the public instance, defaults
 		to "https://pypi.org"
 		"""
 		self.base_pypi_url = base_pypi_url
-		self.pypi_api = base_pypi_url + "/pypi/"
-		self.pypi_search = base_pypi_url + "/simple/"
+		self.pypi_api = base_pypi_url + "/pypi/" if base_pypi_url else None
+		self.pypi_search = base_pypi_url + "/simple/" if base_pypi_url else None
 
 	def resolve_requirements(
 		self,
@@ -57,6 +66,11 @@ class PackageInfoManager:
 
 		except RuntimeError as e:
 			logger.warning(e)
+
+			if self.base_pypi_url != "https://pypi.org":
+				msg = "Custom --pypi-api is not implemented for fallback resolver"
+				raise NotImplementedError(msg) from e
+
 			pyproject = {}
 			if "pyproject.toml" in requirements_paths:
 				pyproject = tomli.loads(Path("pyproject.toml").read_text("utf-8"))
@@ -92,19 +106,24 @@ class PackageInfoManager:
 		"""
 		pkg_info = PackageInfo(name=package.name, version=package.version, errorCode=1)
 
-		lpi = LocalPackageInfo(package=package)
-		rpi = RemotePackageInfo(pypi_api=self.pypi_api, package=package)
+		pkg_info_getters: list[LocalPackageInfo | RemotePackageInfo] = [
+			LocalPackageInfo(package=package),
+		]
+		rpi: RemotePackageInfo | None = None
+		if self.pypi_api is not None:
+			rpi = RemotePackageInfo(pypi_api=self.pypi_api, package=package)
+			pkg_info_getters.append(rpi)
 
 		pkg_info = PackageInfo(
 			name=package.name,
-			version=lpi.get_version() or rpi.get_version(),
-			size=lpi.get_size() or rpi.get_size(),
-			homePage=lpi.get_homePage() or rpi.get_homePage(),
-			author=lpi.get_author() or rpi.get_author(),
-			license=ucstr(lpi.get_license() or rpi.get_license()),
+			version=get_first_not_null(pi.get_version() for pi in pkg_info_getters),
+			size=get_first_not_null(pi.get_size() for pi in pkg_info_getters) or -1,
+			homePage=get_first_not_null(pi.get_homePage() for pi in pkg_info_getters),
+			author=get_first_not_null(pi.get_author() for pi in pkg_info_getters),
+			license=ucstr(get_first_not_null(pi.get_license() for pi in pkg_info_getters)),
 		)
 
-		if rpi.error_state:
+		if rpi is not None and rpi.error_state:
 			pkg_info.errorCode = 1
 
 		if pkg_info.license:
@@ -162,17 +181,17 @@ class LocalPackageInfo:
 	def get_author(self) -> str | None:
 		return meta_get(self.meta, "Author") or meta_get(self.meta, "Author-email")
 
-	def get_size(self) -> int:
+	def get_size(self) -> int | None:
 		"""Retrieve installed package size.
 
 		:param ucstr package: Package name.
-		:return int: Size in bytes.
+		:return int: Size in bytes (or None if not found).
 		"""
 		try:
 			package_files = metadata.Distribution.from_name(self.package.name).files
 			return sum(f.size for f in package_files if f.size) if package_files else 0
 		except metadata.PackageNotFoundError:
-			return 0  # Package not found
+			return None  # Package not found
 
 
 class RemotePackageInfo:
@@ -237,18 +256,18 @@ class RemotePackageInfo:
 		self.poke_pypi()
 		return meta_get(self.raw_data, "author")
 
-	def get_size(self) -> int:
+	def get_size(self) -> int | None:
 		"""Retrieve package size from PyPI metadata.
 
 		:param dict[str, Any] data: PyPI response JSON.
 
-		:return int: Package size in bytes.
+		:return int: Package size in bytes (or None if not found).
 		"""
 		self.poke_pypi()
 		if self.raw_data is None:
-			return -1
+			return None
 		urls = self.raw_data.get("urls", [])
-		return int(urls[-1]["size"]) if len(urls) > 0 else -1
+		return int(urls[-1]["size"]) if urls else None
 
 
 def meta_get(meta: Message | dict[str, Any], key: str) -> str | None:

--- a/licensecheck/packageinfo.py
+++ b/licensecheck/packageinfo.py
@@ -135,8 +135,10 @@ class LocalPackageInfo:
 			self.meta = Message()
 
 	def get_license(self) -> str | None:
+		# ref: https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
 		return (
-			meta_get(self.meta, "License_Expression")
+			meta_get(self.meta, "License-Expression")
+			or meta_get(self.meta, "License_Expression")
 			or from_classifiers(self.meta.get_all("Classifier"))
 			or meta_get(self.meta, "License")
 		)
@@ -147,11 +149,18 @@ class LocalPackageInfo:
 	def get_version(self) -> str | None:
 		return meta_get(self.meta, "Version")
 
+	def _get_homepage_from_project_urls(self) -> str | None:
+		project_urls = self.meta.get_all("Project-URL") or []
+		for line in project_urls:
+			if line.lower().startswith("homepage, "):
+				return line[10:] # no removeprefix to be case insensitive
+		return None
+
 	def get_homePage(self) -> str | None:
-		return meta_get(self.meta, "Home-page")
+		return meta_get(self.meta, "Home-page") or self._get_homepage_from_project_urls()
 
 	def get_author(self) -> str | None:
-		return meta_get(self.meta, "Author")
+		return meta_get(self.meta, "Author") or meta_get(self.meta, "Author-email")
 
 	def get_size(self) -> int:
 		"""Retrieve installed package size.

--- a/licensecheck/resolvers/uv.py
+++ b/licensecheck/resolvers/uv.py
@@ -17,7 +17,7 @@ def get_reqs(
 	groups: list[str],
 	extras: list[str],
 	requirementsPaths: list[str],
-	index_url: str = "https://pypi.org/simple",
+	index_url: str | None = "https://pypi.org/simple",
 ) -> set[PackageInfo]:
 	for idx, requirement in enumerate(requirementsPaths):
 		if not Path(requirement).exists():
@@ -30,14 +30,12 @@ def get_reqs(
 			shutil.copy(requirement, destination_file)
 			requirementsPaths[idx] = destination_file.as_posix()
 
-	groups_cmd = [f"--group {group}" for group in groups]
-	extras_cmd = [f"--extra {extra}" for extra in extras]
-	command = (
-		f"uv pip compile --index {index_url}"
-		f" {' '.join(requirementsPaths)} {' '.join(extras_cmd)} {' '.join(groups_cmd)}"
-	)
+	groups_cmd = sum([("--group", group) for group in groups], ())
+	extras_cmd = sum([("--extra", extra) for extra in extras], ())
+	index_param = ("--index", index_url) if index_url else ()
+	command = ["uv", "pip", "compile", *index_param, *requirementsPaths, *extras_cmd, *groups_cmd]
 
-	result = subprocess.run(command, shell=True, capture_output=True, text=True, check=False)
+	result = subprocess.run(command, capture_output=True, text=True, check=False)
 
 	if result.returncode != 0:
 		raise RuntimeError(result.stderr, result.stdout)

--- a/tests/platform_independent/test_packageinfo.py
+++ b/tests/platform_independent/test_packageinfo.py
@@ -59,14 +59,14 @@ def test_getPackageInfoPypi(remote_package_info: RemotePackageInfo) -> None:
 
 def test_getPackageInfoLocalNotFound() -> None:
 	pkg = LocalPackageInfo(aux_packageinfo("this_package_does_not_exist"))
-	assert pkg.get_size() == 0
+	assert pkg.get_size() is None
 
 
 def test_getPackagePypiLocalNotFound() -> None:
 	pkg = RemotePackageInfo(
 		"https://pypi.org/pypi/", aux_packageinfo("this_package_does_not_exist")
 	)
-	assert pkg.get_size() == -1
+	assert pkg.get_size() is None
 
 
 def test_getPackages(package_info_manager: PackageInfoManager) -> None:


### PR DESCRIPTION
<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix (specs conformance)
- [X] New feature
- [ ] Other (please explain):

### Overview of Changes

Two-fold:
- fix/specs: we add missing metadata keys in `LocalPackageInfo`, especially [`License-Expression`](https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression)
- feat: we add the ability for the user to retrieve package metadata only from local by setting an empty `--pypi-api` argument

### Related Issue

No opened issue but when dealing with a non-public PyPI package only having `License-Expression` metadata, licensecheck was failing to retrieve its license from local metadata.
