### PR TITLE
Fix running licensecheck without any config files

### DIFF
--- a/licensecheck/cli.py
+++ b/licensecheck/cli.py
@@ -144,8 +144,8 @@ def main(args: dict) -> int:
 	for file in config_files:
 		config += Config.from_path(file, optional=True)
 
-	scopedData: ConfigNode = config.get("tool", default={}).get(
-		"licensecheck", default=ConfigNode()
+	scopedData: ConfigNode = config.get("tool", {}).get(
+		"licensecheck", ConfigNode()
 	)
 	scopedConfig = {**scopedData.data, **args}
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

The following error was thrown with no config files:

```
TypeError: dict.get() takes no keyword arguments
```

This PR fixes this bug by fixing a dictionary `get` call.

### Related Issue

Related to https://github.com/FHPythonUtils/LicenseCheck/issues/81

### Reviewer Focus

N/A

### Additional Notes

This was probably never caught because in testing there was always a config file. `configurator`'s `Config`  class allows the keyword `default` argument, but Python dictionaries do not (see second line change).
