### PR TITLE
Bugfix load the show_only_failing from the config

### DIFF
--- a/licensecheck/cli.py
+++ b/licensecheck/cli.py
@@ -200,7 +200,7 @@ def main(args: dict) -> int:
 				this_license,
 				sorted(depsWithLicenses),
 				hide_output_parameters,
-				show_only_failing=args.get("show_only_failing", False),
+				show_only_failing=scopedConfig.get.get("show_only_failing", False),
 			),
 			file=output_file,
 		)


### PR DESCRIPTION
<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

Load the show_only_failing value from the config rather than just the CLI arguments as this ensures that a value used in the config is used as specified in the documentation.
