### PR TITLE
Allow waiting for sqlite locks in request cache

### DIFF
--- a/licensecheck/session.py
+++ b/licensecheck/session.py
@@ -4,4 +4,7 @@ from platformdirs import PlatformDirs
 dirs = PlatformDirs("licensecheck", "fredhappyface")
 
 
-session = requests_cache.CachedSession(dirs.user_cache_dir)
+session = requests_cache.CachedSession(
+	dirs.user_cache_dir,
+	busy_timeout=5000,
+)


### PR DESCRIPTION
<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

Allow waiting for sqlite db locks.

I currently don't have a way to reproduce this issue, but we've seen runs fail for contention for locks in the sqlite cache that backs requests_cache by default.  I believe this happens even without the multithreading change you recently took at https://github.com/FHPythonUtils/LicenseCheck/pull/143, although that could be due to multiple runs of licensechecker at one time.

### Related Issue

If this pull request addresses a specific issue, please mention it using the
format "Fixes #IssueNumber"

Fixes #

### Reviewer Focus

Is there anything specific you would like reviewers to pay attention to while
reviewing this pull request? For example, areas of the code that you'd like to
be thoroughly reviewed or tested?

### Additional Notes

Feel free to add any other relevant information or context that would assist in
the review process.
